### PR TITLE
Fix vitest config

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,7 +6,7 @@ export default mergeConfig(
   defineConfig({
     test: {
       globals: true,
-      exclude: [],
+      // Use Vitest defaults for exclusion (node_modules, dist, etc.)
     },
   }),
 );


### PR DESCRIPTION
## Summary
- fix vitest config so node_modules aren't tested

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6888a67b557c832f828c086c30e0fad3